### PR TITLE
[server] Allow `ENGINE_NAME` to be set by `NAVAJO_ENGINE_NAME` environment variable

### DIFF
--- a/src/navajo/server/api.py
+++ b/src/navajo/server/api.py
@@ -41,7 +41,7 @@ def _load_api_key():
 
 openai.api_key = _load_api_key()
 TOTAL_EMBED_CALLS = 0
-ENGINE_NAME = 'gpt-4'
+ENGINE_NAME = os.environ.get('NAVAJO_ENGINE_NAME', 'gpt-4')
 EMBED_LEN = 1536
 MAX_EMBED_TOKENS = 8191
 MAX_CHAT_TOKENS = {


### PR DESCRIPTION
I don't have `gpt-4` API access at the moment so need to use `gpt-3.5-turbo`. This is an easy/hacky way to override `ENGINE_NAME` without building out any sort of configuration stuff.

Test Plan:
Before: API requests were failing as seen in `codetalk-server.log` logs.
<img width="794" alt="76f08a" src="https://user-images.githubusercontent.com/32692685/233810909-bcc34ea9-e117-4696-a051-4d0ae2e92c4d.png">


After: API requests are succeeding and I'm getting reasonable results.
<img width="553" alt="4c55b6" src="https://user-images.githubusercontent.com/32692685/233810891-0923129d-31ae-488b-94ed-7f2ef853e49d.png">

